### PR TITLE
Correct schematic.pdf extension to png

### DIFF
--- a/keyboard/README.md
+++ b/keyboard/README.md
@@ -118,7 +118,7 @@ The following images show the space bar and other stabilizers mounted onto the P
 
 ## Resources
 
-* Schematic: [schematic.pdf](./schematic.pdf "Schematic")
+* Schematic: [schematic.png](./schematic.png "Schematic")
 
 ## Other references
 


### PR DESCRIPTION
It seems the PDF file is gone and replaced by a PNG one.